### PR TITLE
ユーザ一覧で削除済のものが先頭に表示される問題を修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,7 +4,7 @@ class UsersController < ApplicationController
   authorize_resource
 
   def index
-    @users = User.unscoped.order('deleted_at ASC, id ASC')
+    @users = User.with_deleted
   end
 
   def new

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -33,6 +33,8 @@ class User < ActiveRecord::Base
 
   default_scope { where('deleted_at IS NULL') }
 
+  scope :with_deleted, -> { unscoped.order('CASE WHEN deleted_at IS NULL THEN 0 ELSE 1 END, deleted_at ASC, id ASC') }
+
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable,
   # :lockable, :timeoutable and :omniauthable


### PR DESCRIPTION
PostgreSQL の場合、NULL が最大値として扱われるため、単純に ORDER BY でソートすることは出来ない。

fixes #46
