### PR TITLE
rake db:test:prepare の呼び出しを削除

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ env:
 bundler_args: "--without development --binstubs"
 script:
 - RAILS_ENV=test bundle exec rake db:migrate --trace
-- bundle exec rake db:test:prepare
 - bundle exec rspec
 before_script:
 - cp config/database.travisci.yml config/database.yml


### PR DESCRIPTION
db:test:prepare タスクは Rails 4.1 で Deprecated となっている。
http://edgeguides.rubyonrails.org/4_1_release_notes.html#active-record-deprecations
