### PR TITLE
Fix Order at settlement ledgers.

### DIFF
--- a/app/controllers/settlement_ledgers_controller.rb
+++ b/app/controllers/settlement_ledgers_controller.rb
@@ -8,7 +8,7 @@ class SettlementLedgersController < ApplicationController
   # GET /settlement_ledgers.json
   def index
     params[:page] ||= 1
-    @settlement_ledgers = SettlementLedger.unscoped
+    @settlement_ledgers = SettlementLedger
     unless params[:target] == "all"
       @settlement_ledgers = @settlement_ledgers.not_completed.not_deleted
     end

--- a/app/controllers/settlement_ledgers_controller.rb
+++ b/app/controllers/settlement_ledgers_controller.rb
@@ -8,7 +8,7 @@ class SettlementLedgersController < ApplicationController
   # GET /settlement_ledgers.json
   def index
     params[:page] ||= 1
-    @settlement_ledgers = SettlementLedger
+    @settlement_ledgers = SettlementLedger.order('ledger_number DESC')
     unless params[:target] == "all"
       @settlement_ledgers = @settlement_ledgers.not_completed.not_deleted
     end

--- a/app/models/settlement_ledger.rb
+++ b/app/models/settlement_ledger.rb
@@ -34,8 +34,6 @@ class SettlementLedger < ActiveRecord::Base
   validates :applicant_user_name, presence: true, length: { maximum: 40 }
   validates :settlement_note, length: { maximum: 40 }
 
-  default_scope { order('ledger_number ASC') }
-
   scope :completed, -> { where('completed_at IS NOT NULL') }
   scope :not_completed, -> { where('completed_at IS NULL') }
   scope :deleted, -> { where('deleted_at IS NOT NULL') }


### PR DESCRIPTION
refs #65.

並び順がおかしいのはデフォルトスコープを解除しているためです。
そして、デフォルトスコープは order のみを指定しています。

ただ、単純に解除したので、台帳番号昇順になってます。
これについては意見を求めます。降順が良いなどの意見があればコメントをお願いします。