### PR TITLE
Remove gem dependency `rails_12factor`.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,8 +59,6 @@ gem 'unicorn'
 # Use debugger
 # gem 'debugger', group: [:development, :test]
 
-gem 'rails_12factor', group: :production
-
 group :development, :test do
   gem 'spring-commands-rspec'
   gem 'rb-fsevent'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,11 +153,6 @@ GEM
     rails-i18n (4.0.3)
       i18n (~> 0.6)
       railties (~> 4.0)
-    rails_12factor (0.0.2)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.2)
-    rails_stdout_logging (0.0.3)
     railties (4.1.6)
       actionpack (= 4.1.6)
       activesupport (= 4.1.6)
@@ -266,7 +261,6 @@ DEPENDENCIES
   pg
   rails (= 4.1.6)
   rails-i18n
-  rails_12factor
   rb-fsevent
   rspec-collection_matchers
   rspec-rails


### PR DESCRIPTION
Heroku 環境用の Gem である rails_12factor を Gemfile から除外しました。
これで AWS 環境は問題なく動作すると思います。

詳細については #71 でも記載しています。
あと、おそらくですが #70 の原因でもあると思います。